### PR TITLE
move to map subdomain

### DIFF
--- a/app/CNAME
+++ b/app/CNAME
@@ -1,1 +1,1 @@
-beta.openaerialmap.org
+map.openaerialmap.org


### PR DESCRIPTION
Moves from `beta.openaerialmap.org` to `map.openaerialmap.org`