### PR TITLE
correct open in id url, fix #198

### DIFF
--- a/app/assets/scripts/components/results_item.js
+++ b/app/assets/scripts/components/results_item.js
@@ -159,15 +159,15 @@ var ResultsItem = React.createClass({
 
   renderTmsOptions: function (tmsUrl, key, direction, aligment, includeMainWMTS) {
     var d = this.props.data;
+    console.log(tmsUrl);
     // Generate the iD URL:
     // grab centroid of the footprint
     var center = centroid(d.geojson).geometry.coordinates;
     // cheat by using current zoom level
     var zoom = this.props.mapView.split(',')[2];
-    var idUrl = 'http://www.openstreetmap.org/edit' +
+    var idUrl = 'http://www.openstreetmap.org/edit?editor=id' +
     '#map=' + [zoom, center[1], center[0]].join('/') +
-    '?' + qs.stringify({
-      editor: 'id',
+    '&' + qs.stringify({
       background: 'custom:' + tmsUrl
     });
 

--- a/app/assets/scripts/components/results_item.js
+++ b/app/assets/scripts/components/results_item.js
@@ -159,7 +159,6 @@ var ResultsItem = React.createClass({
 
   renderTmsOptions: function (tmsUrl, key, direction, aligment, includeMainWMTS) {
     var d = this.props.data;
-    console.log(tmsUrl);
     // Generate the iD URL:
     // grab centroid of the footprint
     var center = centroid(d.geojson).geometry.coordinates;


### PR DESCRIPTION
Having `#` before `?editor` seems to cause osm.org to not open in iD or load the custom tiles. This reorganizes the url a bit and now opens the imagery in iD.

fix #198