### PR TITLE
Button to zoom-to-fit selected imagery on screen

### DIFF
--- a/app/assets/scripts/actions/actions.js
+++ b/app/assets/scripts/actions/actions.js
@@ -32,7 +32,7 @@ module.exports = Reflux.createActions({
   // openModal(which)
   'openModal': {},
 
-  'geocoderResult': {},
+  'fitToBounds': {},
 
   'requestMyLocation': {},
 

--- a/app/assets/scripts/components/header.js
+++ b/app/assets/scripts/components/header.js
@@ -66,7 +66,7 @@ var Header = React.createClass({
         console.warn('geocoder -- no result was found');
         return;
       }
-      actions.geocoderResult(bounds);
+      actions.fitToBounds(bounds);
     });
   },
 
@@ -81,7 +81,6 @@ var Header = React.createClass({
 
   onBrowseLatestClick: function (e) {
     e.preventDefault();
-    // console.groupCollapsed('onBrowseLatestClick');
     var previewZoom = 10;
     var latest = mapStore.getLatestImagery();
     var f = {
@@ -92,14 +91,7 @@ var Header = React.createClass({
     var quadKey = utils.quadkeyFromCoords(center[0], center[1], previewZoom);
     var mapView = center[0] + ',' + center[1] + ',' + previewZoom;
 
-    // console.log('Feature', f);
-    // console.log('coords center', center);
-    // console.log('quadKey', quadKey);
-    // console.log('full url -- %s/%s/%s', mapView, quadKey, latest._id);
-
     hashHistory.push(`/${mapView}/${quadKey}/${latest._id}`);
-
-    // console.groupEnd('onBrowseLatestClick');
   },
 
   render: function () {

--- a/app/assets/scripts/components/home.js
+++ b/app/assets/scripts/components/home.js
@@ -119,7 +119,8 @@ var Home = React.createClass({
 
         <MapBoxMap
           query={this.props.query}
-          mapView={this.state.map.view}
+          params={this.props.params}
+          map={this.state.map}
           selectedSquareQuadkey={this.state.selectedSquareQuadkey}
           selectedItemId={this.state.selectedItemId}
           selectedItem={selectedItem}
@@ -130,11 +131,11 @@ var Home = React.createClass({
           selectedSquare={this.props.params.square}
           selectedSquareQuadkey={this.state.selectedSquareQuadkey}
           selectedItemId={this.state.selectedItemId}
-          mapView={this.state.map.view} />
+          map={this.state.map} />
 
         <ResultsPane
           query={this.props.query}
-          mapView={this.state.map.view}
+          map={this.state.map}
           results={this.state.results}
           selectedItemId={this.state.selectedItemId}
           selectedSquareQuadkey={this.state.selectedSquareQuadkey} />

--- a/app/assets/scripts/components/minimap.js
+++ b/app/assets/scripts/components/minimap.js
@@ -13,7 +13,7 @@ var MiniMap = React.createClass({
 
   propTypes: {
     query: React.PropTypes.object,
-    mapView: React.PropTypes.string,
+    map: React.PropTypes.object,
     selectedSquare: React.PropTypes.string,
     selectedSquareQuadkey: React.PropTypes.string,
     selectedItemId: React.PropTypes.string
@@ -70,7 +70,7 @@ var MiniMap = React.createClass({
 
   // Map event.
   onMapClick: function (e) {
-    var zoom = this.props.mapView.split(',')[2];
+    var zoom = this.props.map.view.split(',')[2];
     var path = utils.getMapViewString(e.latlng.lng, e.latlng.lat, zoom);
     if (this.props.selectedSquareQuadkey) {
       path += `/${this.props.selectedSquareQuadkey}`;

--- a/app/assets/scripts/components/results_list.js
+++ b/app/assets/scripts/components/results_list.js
@@ -10,7 +10,7 @@ var ResultsListItem = React.createClass({
 
   propTypes: {
     query: React.PropTypes.object,
-    mapView: React.PropTypes.string,
+    map: React.PropTypes.object,
     selectedSquareQuadkey: React.PropTypes.string,
     data: React.PropTypes.object
   },
@@ -19,8 +19,8 @@ var ResultsListItem = React.createClass({
     e.preventDefault();
     actions.resultOut(this.props.data);
 
-    let { mapView, selectedSquareQuadkey } = this.props;
-    let path = `${mapView}/${selectedSquareQuadkey}/${this.props.data._id}`;
+    let { map, selectedSquareQuadkey } = this.props;
+    let path = `${map.view}/${selectedSquareQuadkey}/${this.props.data._id}`;
     hashHistory.push({pathname: path, query: this.props.query});
   },
 
@@ -69,7 +69,7 @@ var ResultsList = React.createClass({
 
   propTypes: {
     query: React.PropTypes.object,
-    mapView: React.PropTypes.string,
+    map: React.PropTypes.object,
     selectedSquareQuadkey: React.PropTypes.string,
     results: React.PropTypes.array
   },
@@ -82,7 +82,7 @@ var ResultsList = React.createClass({
       return <ResultsListItem
         key={o._id}
         query={this.props.query}
-        mapView={this.props.mapView}
+        map={this.props.map}
         selectedSquareQuadkey={this.props.selectedSquareQuadkey}
         data={o} />;
     });

--- a/app/assets/scripts/components/results_pane.js
+++ b/app/assets/scripts/components/results_pane.js
@@ -130,16 +130,16 @@ var ResultsPane = React.createClass({
           </ul>
         </Dropdown>
 
-        <a href='' onClick={this.closeResults} className='pane-dismiss' title='Exit selection'>
-          <span>Close</span>
-        </a>
-
         <a
           href=''
           onClick={this.zoomToFit}
           className={`pane-zoom-to-fit ${this.currentResult === null && 'visually-hidden'}`}
           title='Zoom to fit imagery on screen'>
           <span>Zoom To Fit</span>
+        </a>
+
+        <a href='' onClick={this.closeResults} className='pane-dismiss' title='Exit selection'>
+          <span>Close</span>
         </a>
 
         {resultsPane}

--- a/app/assets/styles/_results-panel.scss
+++ b/app/assets/styles/_results-panel.scss
@@ -40,19 +40,19 @@
   }
 }
 
-.pane-zoom-to-fit {
+.pane-more {
   @extend .pane-top-control;
   right: 4.5rem;
   &:before {
-    @extend %oam-ds-icon-location;
+    @extend %oam-ds-icon-ellipsis-vertical;
   }
 }
 
-.pane-more {
+.pane-zoom-to-fit {
   @extend .pane-top-control;
   right: 2.5rem;
   &:before {
-    @extend %oam-ds-icon-ellipsis-vertical;
+    @extend %oam-ds-icon-crosshair-2;
   }
 }
 
@@ -64,8 +64,8 @@
   }
 }
 
-.pane-zoom-to-fit,
 .pane-more,
+.pane-zoom-to-fit,
 .pane-dismiss {
   color: tint($base-color, 64%);
   &:visited {

--- a/app/assets/styles/_results-panel.scss
+++ b/app/assets/styles/_results-panel.scss
@@ -24,16 +24,14 @@
   margin: -1rem;
 }
 
-.pane-dismiss {
+.pane-top-control {
   position: absolute;
   top: 0.75rem;
-  right: 0.5rem;
   z-index: 30;
   span {
     @extend .visually-hidden;
   }
   &:before {
-    @extend %oam-ds-icon-sm-xmark;
     display: block;
     height: 2rem;
     width: 2rem;
@@ -42,32 +40,37 @@
   }
 }
 
-.pane-dismiss,
-.pane-dismiss:visited {
-  color: tint($base-color, 64%);
+.pane-zoom-to-fit {
+  @extend .pane-top-control;
+  right: 4.5rem;
+  &:before {
+    @extend %oam-ds-icon-location;
+  }
 }
 
 .pane-more {
-  position: absolute;
-  top: 0.75rem;
+  @extend .pane-top-control;
   right: 2.5rem;
-  z-index: 30;
-  span {
-    @extend .visually-hidden;
-  }
   &:before {
     @extend %oam-ds-icon-ellipsis-vertical;
-    display: block;
-    height: 2rem;
-    width: 2rem;
-    line-height: 2rem;
-    text-align: center;
   }
 }
 
+.pane-dismiss {
+  @extend .pane-top-control;
+  right: 0.5rem;
+  &:before {
+    @extend %oam-ds-icon-sm-xmark;
+  }
+}
+
+.pane-zoom-to-fit,
 .pane-more,
-.pane-more:visited {
+.pane-dismiss {
   color: tint($base-color, 64%);
+  &:visited {
+    color: inherit;
+  }
 }
 
 .pane-header {
@@ -92,6 +95,9 @@
   padding-right: 3.5rem;
   @include heading(1rem);
   @extend .truncated;
+  &.with-zoom-to-fit {
+    padding-right: 5.5em;
+  }
 }
 
 .pane-subtitle {


### PR DESCRIPTION
I started off by adding a new property to the `props.map` object, that's
why you'll see so many changes of `mapView` => `map.view`. However I
soon realised that reflux actions was the better method. But I kept the
`map.view` changes in this commit, just because it seems like a more
convenient starting point, should the `props.map` object need any new
properties in the future.

Looking at the existing reflux actions I saw that `geocoderResult` was
already doing the exact same thing (namely fitting the map to a given
bounding box), so I simply refactored that function to reflect its more
general usage.

There are also a lot of formatting changes here: line lengths, indenting
etc. I generally tidied up within the vicinity of whatever I was working
on.

Fixes #151
