### PR TITLE
Support zooming to imagery's highest zoom

### DIFF
--- a/app/assets/scripts/actions/actions.js
+++ b/app/assets/scripts/actions/actions.js
@@ -28,6 +28,7 @@ module.exports = Reflux.createActions({
   // Results pane related actions.
   'resultOver': {},
   'resultOut': {},
+  'resultSelected': {},
 
   // openModal(which)
   'openModal': {},

--- a/app/assets/scripts/components/filters.js
+++ b/app/assets/scripts/components/filters.js
@@ -56,7 +56,7 @@ var Filters = React.createClass({
       query[prop] = value;
     }
 
-    var mapView = this.props.params.map;
+    var mapView = this.props.params.map.view;
     if (!mapView) {
       var cookieView = cookie.read('oam-browser:map-view');
       if (cookieView !== 'undefined') {

--- a/app/assets/scripts/components/home.js
+++ b/app/assets/scripts/components/home.js
@@ -40,7 +40,6 @@ var Home = React.createClass({
   },
 
   onMapStoreData: function (what) {
-    // console.log('onMapStoreData', mapStore.storage);
     var state = _.cloneDeep(this.state);
     state.results = mapStore.getResults();
     state.loading = what === 'squareData' ? false : mapStore.footprintsWereFecthed();
@@ -49,7 +48,6 @@ var Home = React.createClass({
 
   // Action listener
   onSearchQueryChanged: function (params) {
-    // console.log('home onSearchQueryChanged');
     this.setState({filterParams: params});
   },
 

--- a/app/assets/scripts/components/map.js
+++ b/app/assets/scripts/components/map.js
@@ -6,6 +6,7 @@ import { hashHistory } from 'react-router';
 import React from 'react';
 import Reflux from 'reflux';
 import _ from 'lodash';
+import $ from 'jquery';
 import tilebelt from 'tilebelt';
 import centroid from 'turf-centroid';
 import inside from 'turf-inside';
@@ -34,6 +35,7 @@ var Map = React.createClass({
   mixins: [
     Reflux.listenTo(actions.resultOver, 'onResultOver'),
     Reflux.listenTo(actions.resultOut, 'onResultOut'),
+    Reflux.listenTo(actions.resultSelected, 'onResultSelected'),
     Reflux.listenTo(actions.selectPreview, 'onSelectPreview'),
     Reflux.listenTo(actions.fitToBounds, 'onFitToBounds'),
     Reflux.listenTo(actions.requestMyLocation, 'onRequestMyLocation'),
@@ -65,17 +67,14 @@ var Map = React.createClass({
 
   componentWillReceiveProps: function (nextProps) {
     this.requireMapViewUpdate = this.props.map.view !== nextProps.map.view;
-
-    const currentSelectedItem = _.get(this.props.selectedItem, '_id', null);
-    const nextSelectedItem = _.get(nextProps.selectedItem, '_id', null);
-    this.requireSelectedItemUpdate = currentSelectedItem !== nextSelectedItem;
+    this.requireSelectedItemUpdate =
+      _.get(this.props.selectedItem, '_id', null) !==
+      _.get(nextProps.selectedItem, '_id', null);
   },
 
   // Lifecycle method.
   // Called once as soon as the component has a DOM representation.
   componentDidMount: function () {
-    // console.log('componentDidMount MapBoxMap');
-
     this.map = L.mapbox.map(this.refs.mapContainer, null, {
       zoomControl: false,
       minZoom: config.map.minZoom,
@@ -87,13 +86,21 @@ var Map = React.createClass({
     this.baseLayer = L.tileLayer(mapStore.getBaseLayer().url);
     this.map.addLayer(this.baseLayer);
 
-    this.refs.mapContainer.classList.add(`base-layer--${mapStore.getBaseLayer().id}`);
+    this.refs.mapContainer.classList.add(
+      `base-layer--${mapStore.getBaseLayer().id}`
+    );
 
     // Edits the attribution to create link out to github issues
     var credits = L.control.attribution().addTo(this.map);
-    credits.addAttribution('© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> | <a href="#" data-hook="map:issue">Report an issue with this map</a>');
+    credits.addAttribution(
+      '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © ' +
+      '<a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> | ' +
+      '<a href="#" data-hook="map:issue">Report an issue with this map</a>'
+    );
 
-    let mapIssueTrigger = this.refs.mapContainer.querySelector('[data-hook="map:issue"]');
+    let mapIssueTrigger = this.refs.mapContainer.querySelector(
+      '[data-hook="map:issue"]'
+    );
     mapIssueTrigger.addEventListener('click', this.onMapIssueReport);
 
     // Custom zoom control.
@@ -105,9 +112,13 @@ var Map = React.createClass({
     });
     this.map.addControl(zoomCtrl);
 
-    this.mapGridLayer = L.geoJson(null, { style: L.mapbox.simplestyle.style }).addTo(this.map);
+    this.mapGridLayer = L.geoJson(null, {
+      style: L.mapbox.simplestyle.style
+    }).addTo(this.map);
     // Footprint layer.
-    this.mapOverFootprintLayer = L.geoJson(null, { style: L.mapbox.simplestyle.style }).addTo(this.map);
+    this.mapOverFootprintLayer = L.geoJson(null, {
+      style: L.mapbox.simplestyle.style
+    }).addTo(this.map);
     this.mapSelectedSquareLayer = L.geoJson(null).addTo(this.map);
 
     this.mapGridLayer.on('mouseover', this.onGridSqrOver);
@@ -129,24 +140,23 @@ var Map = React.createClass({
   // Lifecycle method.
   // Called when the component gets updated.
   componentDidUpdate: function (prevProps, prevState) {
-    // console.log('componentDidUpdate');
-
     // Is there a need to update the map view.
     if (this.requireMapViewUpdate) {
       var routerMap = this.stringToMapView(this.props.map.view);
       this.map.setView([routerMap.lat, routerMap.lng], routerMap.zoom);
-      // console.log('componentDidUpdate', 'map view updated');
     }
     this.updateGrid();
     this.updateSelectedSquare();
 
     if (this.requireSelectedItemUpdate) {
-      this.updateSelectedItemImageFootprint({type: 'thumbnail'});
+      this.updateSelectedItemImageFootprint({ type: 'thumbnail' });
     }
   },
 
   componentWillUnmount: function () {
-    let mapIssueTrigger = this.refs.mapContainer.querySelector('[data-hook="map:issue"]');
+    let mapIssueTrigger = this.refs.mapContainer.querySelector(
+      '[data-hook="map:issue"]'
+    );
     mapIssueTrigger.removeEventListener('click', this.onMapIssueReport);
   },
 
@@ -154,7 +164,7 @@ var Map = React.createClass({
   render: function () {
     return (
       <div>
-        <div id='map' ref='mapContainer'></div>
+        <div id='map' ref='mapContainer' />
       </div>
     );
   },
@@ -166,7 +176,6 @@ var Map = React.createClass({
 
   // Map event
   onMapMoveend: function (e) {
-    // console.log('event:', 'moveend');
     var path = this.mapViewToString();
     if (this.props.selectedSquareQuadkey) {
       path += `/${this.props.selectedSquareQuadkey}`;
@@ -175,7 +184,7 @@ var Map = React.createClass({
       path += `/${this.props.selectedItemId}`;
     }
 
-    hashHistory.replace({pathname: path, query: this.props.query});
+    hashHistory.replace({ pathname: path, query: this.props.query });
   },
 
   // Map event
@@ -203,16 +212,21 @@ var Map = React.createClass({
     e.layer.closePopup();
 
     if (this.props.selectedSquareQuadkey) {
-      // console.log('onGridSqrClick', 'There was a square selected. UNSELECTING');
       // There is a square selected. Unselect.
-      hashHistory.push({pathname: `/${this.props.map.view}`, query: this.props.query});
+      hashHistory.push({
+        pathname: `/${this.props.map.iew}`,
+        query: this.props.query
+      });
     } else if (e.layer.feature.properties.count) {
       // console.log('onGridSqrClick', 'No square selected. SELECTING');
       var quadKey = e.layer.feature.properties._quadKey;
       var z = Math.round(this.map.getZoom());
       var squareCenter = centroid(e.layer.feature).geometry.coordinates;
       var mapView = utils.getMapViewString(squareCenter[0], squareCenter[1], z);
-      hashHistory.push({pathname: `/${mapView}/${quadKey}`, query: this.props.query});
+      hashHistory.push({
+        pathname: `/${mapView}/${quadKey}`,
+        query: this.props.query
+      });
     }
   },
 
@@ -227,7 +241,10 @@ var Map = React.createClass({
   // Actions listener.
   onChangeBaseLayer: function () {
     let layer = mapStore.getBaseLayer();
-    this.refs.mapContainer.className = this.refs.mapContainer.className.replace(/\bbase-layer--\S*/, '');
+    this.refs.mapContainer.className = this.refs.mapContainer.className.replace(
+      /\bbase-layer--\S*/,
+      ''
+    );
     this.refs.mapContainer.classList.add(`base-layer--${layer.id}`);
     if (this.baseLayer) {
       this.map.removeLayer(this.baseLayer);
@@ -238,16 +255,19 @@ var Map = React.createClass({
 
   // Actions listener.
   onRequestMyLocation: function () {
-    navigator.geolocation.getCurrentPosition(position => {
-      let {longitude, latitude} = position.coords;
-      let mapView = utils.getMapViewString(longitude, latitude, 15);
-      hashHistory.push({pathname: `/${mapView}`, query: this.props.query});
-    }, err => {
-      console.warn('my location error', err);
-    });
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        let { longitude, latitude } = position.coords;
+        let mapView = utils.getMapViewString(longitude, latitude, 15);
+        hashHistory.push({ pathname: `/${mapView}`, query: this.props.query });
+      },
+      err => {
+        console.warn('my location error', err);
+      }
+    );
   },
 
-  // Action listener
+  // Action listener for when mouse enters a result in the results modal
   onResultOver: function (feature) {
     var f = utils.getPolygonFeature(feature.geojson.coordinates);
     this.mapOverFootprintLayer.clearLayers().addData(f);
@@ -256,15 +276,21 @@ var Map = React.createClass({
     });
   },
 
-  // Action listener
+  // Action listener for when the mouse leaves a result in the results modal
   onResultOut: function () {
     this.mapOverFootprintLayer.clearLayers();
   },
 
+  // Action listener for when a result in the results modal is clicked
+  onResultSelected: function (result) {
+    this.onResultOut();
+    let { map, selectedSquareQuadkey } = result;
+    let path = `${map.view}/${selectedSquareQuadkey}/${result.data._id}`;
+    hashHistory.push({ pathname: path, query: result.query });
+  },
+
   updateGrid: function () {
     var _this = this;
-    // console.groupCollapsed('updateGrid');
-    // console.log('filterparams', this.props.filterParams);
     this.mapGridLayer.clearLayers();
 
     // Recompute grid based on current map view (bounds + zoom).
@@ -280,62 +306,67 @@ var Map = React.createClass({
       // Get all the footprints inside the current square.
       var foots = mapStore.getFootprintsInSquare(gridSquare);
       // Filter with whatever filters are set.
-      foots = foots.filter(function (foot) {
-        var filter = _this.props.filterParams;
-        var prop = foot.feature.properties;
+      foots = foots
+        .filter(function (foot) {
+          var filter = _this.props.filterParams;
+          var prop = foot.feature.properties;
 
-        // Data type.
-        if (filter.dataType !== 'all' && !prop.tms) {
-          return false;
-        }
-
-        // Resolution.
-        switch (filter.resolution) {
-          // >=5
-          case 'low':
-            if (prop.gsd < 5) {
-              return false;
-            }
-            break;
-          // <5 && >=1
-          case 'medium':
-            if (prop.gsd >= 5 || prop.gsd < 1) {
-              return false;
-            }
-            break;
-          // < 1
-          case 'high':
-            if (prop.gsd >= 1) {
-              return false;
-            }
-            break;
-        }
-
-        // Date.
-        if (filter.date !== 'all') {
-          var d = new Date();
-          if (filter.date === 'week') {
-            d.setDate(d.getDate() - 7);
-          } else if (filter.date === 'month') {
-            d.setMonth(d.getMonth() - 1);
-          } else if (filter.date === 'year') {
-            d.setFullYear(d.getFullYear() - 1);
-          }
-
-          if ((new Date(prop.acquisition_end)).getTime() < d.getTime()) {
+          // Data type.
+          if (filter.dataType !== 'all' && !prop.tms) {
             return false;
           }
-        }
 
-        return true;
-      })
-      // Filter to ensure that the footprint is really inside the square
-      // an not just its bounding box.
-      .filter(function (foot) {
-        var footprint = foot.feature;
-        var footprintCenter = centroid(footprint);
-        return inside(featureCenter, footprint) || inside(footprintCenter, gridSquare) || overlaps(footprint, gridSquare);
-      });
+          // Resolution.
+          switch (filter.resolution) {
+            // >=5
+            case 'low':
+              if (prop.gsd < 5) {
+                return false;
+              }
+              break;
+            // <5 && >=1
+            case 'medium':
+              if (prop.gsd >= 5 || prop.gsd < 1) {
+                return false;
+              }
+              break;
+            // < 1
+            case 'high':
+              if (prop.gsd >= 1) {
+                return false;
+              }
+              break;
+          }
+
+          // Date.
+          if (filter.date !== 'all') {
+            var d = new Date();
+            if (filter.date === 'week') {
+              d.setDate(d.getDate() - 7);
+            } else if (filter.date === 'month') {
+              d.setMonth(d.getMonth() - 1);
+            } else if (filter.date === 'year') {
+              d.setFullYear(d.getFullYear() - 1);
+            }
+
+            if (new Date(prop.acquisition_end).getTime() < d.getTime()) {
+              return false;
+            }
+          }
+
+          return true;
+        })
+        // Filter to ensure that the footprint is really inside the square
+        // an not just its bounding box.
+        .filter(function (foot) {
+          var footprint = foot.feature;
+          var footprintCenter = centroid(footprint);
+          return (
+            inside(featureCenter, footprint) ||
+            inside(footprintCenter, gridSquare) ||
+            overlaps(footprint, gridSquare)
+          );
+        });
       gridSquare.properties.count = foots.length;
     });
     // console.timeEnd('aggregate on grid');
@@ -394,15 +425,26 @@ var Map = React.createClass({
     }
   },
 
+  // When zoomed in to a layer that accepts high zoom levels and that
+  // layer is removed, we need to zoom backk out to the default max
+  // zoom, but still remain centred on the same coord.
+  correctOverZoom: function () {
+    this.map.options.maxZoom = config.map.maxZoom;
+    if (this.map.getZoom() > config.map.maxZoom) {
+      this.map.setZoom(config.map.maxZoom);
+      this.onMapMoveend();
+    }
+  },
+
   updateSelectedItemImageFootprint: function (previewOptions) {
     this.disableSelectedSquare = false;
     if (this.map.hasLayer(this.mapOverImageLayer)) {
       this.map.removeLayer(this.mapOverImageLayer);
       this.mapOverImageLayer = null;
+      this.correctOverZoom();
     }
     if (this.props.selectedItem) {
       var item = this.props.selectedItem;
-
       if (previewOptions.type === 'tms') {
         // We can preview the main tms and the custom ones as well.
         // When previewing the main tms the index property won't be set.
@@ -411,19 +453,43 @@ var Map = React.createClass({
         let tmsUrl = previewOptions.index === undefined
           ? item.properties.tms
           : item.custom_tms[previewOptions.index];
-
-        // Fix url. Mostly means changing {zoom} to {z}.
         tmsUrl = tmsUrl.replace('{zoom}', '{z}');
-        this.mapOverImageLayer = L.tileLayer(tmsUrl);
-        this.disableSelectedSquare = true;
-      } else if (previewOptions.type === 'thumbnail') {
-        var imageBounds = [[item.bbox[1], item.bbox[0]], [item.bbox[3], item.bbox[2]]];
-        this.mapOverImageLayer = L.imageOverlay(item.properties.thumbnail, imageBounds);
-      }
 
+        this.disableSelectedSquare = true;
+        const layerMaxZoom = this.getLayerMaxZoom(item.properties.tms);
+        this.map.options.maxZoom = layerMaxZoom;
+        this.mapOverImageLayer = L.tileLayer(tmsUrl, { maxZoom: layerMaxZoom });
+      } else if (previewOptions.type === 'thumbnail') {
+        var imageBounds = [
+          [item.bbox[1], item.bbox[0]],
+          [item.bbox[3], item.bbox[2]]
+        ];
+        this.mapOverImageLayer = L.imageOverlay(
+          item.properties.thumbnail,
+          imageBounds
+        );
+      }
       this.mapOverImageLayer && this.map.addLayer(this.mapOverImageLayer);
     }
     this.updateSelectedSquare();
+  },
+
+  // Mapbox.js doesn't seem to account for the new zoom levels when adding a layer.
+  // So we need to fetch the tilejSON data over HTTP, parse it for the max zoom,
+  // then apply it both to the map to adjust the zoom controls and the layer to make
+  // it trigger the relevant HTTP tiling requests for zoom levels above the deffault
+  // 18.
+  // TODO: Add layer's tileJSON, or relevant portions thereof, to oin-meta-generator.
+  //       This will prevent the need for;
+  //       1. Hacking the `tms` field to get the base tileJSON URI.
+  //       2. Making a blocking synchronous XHR call.
+  getLayerMaxZoom: function (tmsURI) {
+    const tileJSONURI = tmsURI.replace(/\/\{z\}\/\{x\}\/\{y\}.*/, '');
+    let maxZoom;
+    $.get({url: tileJSONURI, async: false}).success((data) => {
+      maxZoom = data.maxzoom;
+    });
+    return maxZoom;
   },
 
   // Helper functions
@@ -439,7 +505,6 @@ var Map = React.createClass({
    * @param {Array} bounds [minx, miny, maxx, maxy]
    */
   computeGrid: function (zoom, bounds) {
-    // console.time('grid');
     // We'll use tilebelt to make pseudo-tiles at a zoom three levels higher
     // than the given zoom.  This means that for each actual map tile, there will
     // be 4^3 = 64 grid squares.

--- a/app/assets/scripts/components/results_list.js
+++ b/app/assets/scripts/components/results_list.js
@@ -1,5 +1,4 @@
 'use strict';
-import { hashHistory } from 'react-router';
 import React from 'react';
 
 import actions from '../actions/actions';
@@ -17,11 +16,7 @@ var ResultsListItem = React.createClass({
 
   onClick: function (e) {
     e.preventDefault();
-    actions.resultOut(this.props.data);
-
-    let { map, selectedSquareQuadkey } = this.props;
-    let path = `${map.view}/${selectedSquareQuadkey}/${this.props.data._id}`;
-    hashHistory.push({pathname: path, query: this.props.query});
+    actions.resultSelected(this.props);
   },
 
   onOver: function (e) {
@@ -40,11 +35,24 @@ var ResultsListItem = React.createClass({
     return (
       <li>
         <article className='card card-result-entry'>
-          <a href='#' onClick={this.onClick} onMouseOver={this.onOver} onMouseOut={this.onOut}>
+          <a
+            href='#'
+            onClick={this.onClick}
+            onMouseOver={this.onOver}
+            onMouseOut={this.onOut}
+          >
             <header className='card-header'>
               <h1 className='card-title'>{d.title}</h1>
               <div className='card-media'>
-                <img alt='Result thumbnail' width='768' height='432' src={d.properties.thumbnail || 'assets/graphics/layout/img-placeholder.svg' } />
+                <img
+                  alt='Result thumbnail'
+                  width='768'
+                  height='432'
+                  src={
+                    d.properties.thumbnail ||
+                      'assets/graphics/layout/img-placeholder.svg'
+                  }
+                />
               </div>
             </header>
             <div className='card-body'>
@@ -52,7 +60,11 @@ var ResultsListItem = React.createClass({
                 <dt>Type</dt>
                 <dd>{d.properties.tms ? 'Image + Map Layer' : 'Image'}</dd>
                 <dt>Date</dt>
-                <dd>{d.acquisition_start ? d.acquisition_start.slice(0, 10) : 'N/A'}</dd>
+                <dd>
+                  {d.acquisition_start
+                    ? d.acquisition_start.slice(0, 10)
+                    : 'N/A'}
+                </dd>
                 <dt>Res</dt>
                 <dd>{utils.gsdToUnit(d.gsd)}</dd>
               </dl>
@@ -90,7 +102,12 @@ var ResultsList = React.createClass({
     return (
       <section className='results-hub'>
         <header className='pane-header'>
-          <h1 className='pane-title' title={'Available imagery for square with quadKey ' + square}>Available Imagery</h1>
+          <h1
+            className='pane-title'
+            title={'Available imagery for square with quadKey ' + square}
+          >
+            Available Imagery
+          </h1>
           <p className='pane-subtitle'>{numRes} results</p>
         </header>
         <div className='pane-body'>
@@ -98,7 +115,7 @@ var ResultsList = React.createClass({
             <ol className='results-list'>{results}</ol>
           </div>
         </div>
-        <footer className='pane-footer'></footer>
+        <footer className='pane-footer' />
       </section>
     );
   }

--- a/app/assets/scripts/components/results_pane.js
+++ b/app/assets/scripts/components/results_pane.js
@@ -48,9 +48,7 @@ var ResultsPane = React.createClass({
   },
 
   closeResults: function (e) {
-    if (e) {
-      e.preventDefault();
-    }
+    if (e) e.preventDefault();
     hashHistory.push({pathname: this.props.map.view, query: this.props.query});
   },
 

--- a/app/assets/scripts/config/production.js
+++ b/app/assets/scripts/config/production.js
@@ -12,7 +12,7 @@ module.exports = {
 
     initialZoom: 3,
     minZoom: 2,
-    maxZoom: undefined,
+    maxZoom: 18,
 
     initialView: [-18.632, 18.479]
   },

--- a/app/assets/scripts/utils/ds_zoom.js
+++ b/app/assets/scripts/utils/ds_zoom.js
@@ -23,12 +23,24 @@ var DSZoom = L.Control.extend({
     var options = this.options;
     var container = L.DomUtil.create('div', options.containerClasses);
 
-    this._zoomInButton = this._createButton(options.zoomInText, options.zoomInClasses, container, this._zoomIn);
-    this._zoomOutButton = this._createButton(options.zoomOutText, options.zoomOutClasses, container, this._zoomOut);
+    this._zoomInButton = this._createButton(
+      options.zoomInText,
+      options.zoomInClasses,
+      container,
+      this._zoomIn
+    );
+    this._zoomOutButton = this._createButton(
+      options.zoomOutText,
+      options.zoomOutClasses,
+      container,
+      this._zoomOut
+    );
 
     this._updateDisabled();
 
-    map.on('zoomend zoomlevelschange', this._updateDisabled, this);
+    // Watch out for the rate at which `layeradd` is called, around 160 times
+    // per map movement. It may be better to use a Reflux action.
+    map.on('zoomend zoomlevelschange layeradd', this._updateDisabled, this);
 
     return container;
   },


### PR DESCRIPTION
Essentially this extends the max zoom on a case by case basis
when an individual imagery layer is selected through the results pane.

Fixes #200.

I had planned to also limit the panning (so the imagery can't leave the
viewport), however the default behaviour of selecting imagery doesn't
focus the map, so there's no consistent entry point for applying new
panning limits. It could be done alongside the zoom-to-fit button
behaviour, but then there is an inconsistency in panning behaviour,
which we be more confusing than helpful. So as it stands this commit
does leave a small UX problem in that you can zoom to a level where the
main map layer disappears, but only when individual imagery is selected.
As soon as imagery is deselected the default max zoom (18) is reset and
you are zoomed back out to the default max zoom if you were browsing
imagery at a higher zoom level.

Notes:
  * Imagery's metadata does not contain the max tile zoom. It needs to be
    fetched separately through the tileJSON manifest, this is somewhat
    hacky and requires a blocking XHR request. We should look to
    include at least the maxZoom level from imagery's tileJSON, or
    perhaps even include the tileJSON by default in the
    `oin-meta-generator` process.
  * Mapbox.js version is missing setMaxZoom(), consider upgrading.
  * The custom DS zoom controls are listening to `layeradd` which gets
    triggered around 150 times per map movement.
  * Commit also contains formatting updates, mainly line length.