### PR TITLE
Post-ajax response when submitting feedback form

### DIFF
--- a/app/assets/scripts/components/modals/feedback_modal.js
+++ b/app/assets/scripts/components/modals/feedback_modal.js
@@ -107,12 +107,10 @@ var FeedbackModal = React.createClass({
         response: null
       });
 
-      $.post(config.feedbackSubmissionURL, {
-        'entry.1992005100': serial.name,
-        'entry.1437255376': serial.email,
-        'entry.1013721428': serial.subject,
-        'entry.212244570': serial.message,
-        'entry.1747851236': serial.path
+      $.ajax({
+        dataType: 'jsonp',
+        url: config.feedbackSubmissionURL,
+        data: serial
       })
         .always(() => {
           this.setState({lockSubmit: false});

--- a/app/assets/scripts/config/production.js
+++ b/app/assets/scripts/config/production.js
@@ -20,5 +20,5 @@ module.exports = {
     url: 'https://api.openaerialmap.org'
   },
   oamStatus: 'https://status.openaerialmap.org/healthcheck',
-  feedbackSubmissionURL: 'https://docs.google.com/a/developmentseed.org/forms/d/1VOcERexikGP5N6xkjPDgUuDLUcS_Ktxj_ALNokNuttc/formResponse'
+  feedbackSubmissionURL: 'https://getsimpleform.com/messages/ajax?form_api_token=506fc2ac58582416b6086a68a343e344'
 };

--- a/app/assets/scripts/config/staging.js
+++ b/app/assets/scripts/config/staging.js
@@ -5,6 +5,7 @@
 
 module.exports = {
   environment: 'staging',
+  feedbackSubmissionURL: 'https://getsimpleform.com/messages/ajax?form_api_token=506fc2ac58582416b6086a68a343e344',
   catalog: {
     url: 'https://oam-catalog-staging.herokuapp.com'
   }


### PR DESCRIPTION
Google forms doesn't provide any HTTP response codes so use
getsimpleform.com to handle sending email -- until we can set up a
new API method to handle it ourselves.

Also includes refactoring of feedback submission URL into config.

Fixes #205