### PR TITLE
Fix stretched thumbnails

### DIFF
--- a/app/assets/styles/_results-panel.scss
+++ b/app/assets/styles/_results-panel.scss
@@ -193,11 +193,11 @@
     position: relative;
     z-index: 2;
     max-width: 100%;
-    height: 100%;
+    max-height: 100%;
     display: inline-block;
     box-shadow: 0 2px 12px 2px rgba($base-color, 0.24);
     border-radius: $base-border-radius / 2;
-    vertical-align: top;
+    vertical-align: middle;
   }
   .blur-media {
     position: absolute;

--- a/test/integration/general_test.js
+++ b/test/integration/general_test.js
@@ -1,9 +1,9 @@
 function waitUntilGone (selector) {
-  browser.waitForExist(selector, 300000, true);
+  browser.waitForVisible(selector, 300000, true);
 }
 
 function finishLoading () {
-  waitUntilGone('.loading.revealed');
+  waitUntilGone('.loading');
 }
 
 describe('Basic', () => {
@@ -20,7 +20,9 @@ describe('Basic', () => {
     finishLoading();
     browser.click('#map');
     finishLoading();
-    const results = $$('.pane-body-inner .results-list li');
+    const resultsSelector = '.pane-body-inner .results-list li';
+    browser.waitForExist(resultsSelector);
+    const results = $$(resultsSelector);
     expect(results.length).to.be.at.least(8);
   });
 });
@@ -35,10 +37,10 @@ describe('Selected Layers', () => {
     finishLoading();
     expect('.button-zoom--in.disabled');
     // Click the 'TMS' button
-    browser.click('.preview-options__buttons:nth-child(2)');
+    browser.click('button=TMS');
     // TODO: waiting here is necessary because of a blocking sync AJAX hack
     // in map.js getLayerMaxZoom().
-    waitUntilGone('.button-zoom--in.disabled', 60000, true);
+    waitUntilGone('.button-zoom--in.disabled');
     const classes = $('.button-zoom--in').getAttribute('class');
     expect(classes).not.to.include('disabled');
   });

--- a/test/integration/wdio.browserstack.conf.js
+++ b/test/integration/wdio.browserstack.conf.js
@@ -25,15 +25,8 @@ let browserStackConf = {
   services: ['browserstack'],
   browserstackLocal: true,
 
-  // TODO: Safari is difficult to trigger a click on the map with.
-  // Safari 10.0 has better support for moveTo() commands, but
-  // it has other problems. Look into selectively running tests
-  // depending on which browsers support the required commands
-  // for that test.
   capabilities: [{
     browserName: 'chrome'
-  }, {
-    browserName: 'firefox'
   }, {
     browserName: 'edge'
   }].map(function (browser) {


### PR DESCRIPTION
Thumbnails for a selected image in the results modal were set to
fill the height of the div. So added a `max-height` and
`vertical-align`.

Fixes hotosm/OpenAerialMap#79