### PR TITLE
get correct maxzoom property, fix #200

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -490,7 +490,7 @@ export default createReactClass({
 
         this.disableSelectedSquare = true;
         this.getLayerMaxZoom(tmsUrl).then(data => {
-          this.map.options.maxZoom = data.layerMaxZoom;
+          this.map.options.maxZoom = data.maxzoom;
           this.mapOverImageLayer = L.tileLayer(tmsUrl, {
             maxZoom: this.map.options.maxZoom
           });


### PR DESCRIPTION
This gets the correct maxzoom property to allow deeper zooming beyond 18 when available. Fix #200. 