### PR TITLE
Update/licenses

### DIFF
--- a/src/components/uploader/home.js
+++ b/src/components/uploader/home.js
@@ -473,13 +473,22 @@ export default createReactClass({
                   <a href="https://github.com/openimagerynetwork/oin-register#open-imagery-network">
                     Open Imagery Network (OIN)
                   </a>
-                  . All imagery contained in OIN is licensed{" "}
+                </p>
+                <p>
+                  Except when permitted by the OpenStreetMap exception (see
+                  below), all imagery contained in OIN is licensed{" "}
                   <a href="https://creativecommons.org/licenses/by/4.0/">
                     CC-BY 4.0
                   </a>
-                  , with attribution as contributors of Open Imagery Network,
-                  unless further specified by a specific license. All imagery is
-                  available to be traced in OpenStreetMap.
+                  , with attribution as "© OIN contributors", and specific
+                  additional SA/NC conditions if selected upon upload.
+                </p>
+                <p>
+                  IMPORTANT NOTICE - OPENSTREETMAP EXCEPTION: You agree that
+                  users do not have to comply with the selected license when the
+                  imagery is used for tracing in OpenStreetMap. In these cases,
+                  you agree that the derived data from the imagery is made
+                  available under the ODBL license.
                 </p>
               </div>
 

--- a/src/components/uploader/home.js
+++ b/src/components/uploader/home.js
@@ -479,8 +479,9 @@ export default createReactClass({
                   <a href="https://creativecommons.org/licenses/by/4.0/">
                     CC-BY 4.0
                   </a>
-                  , with attribution as contributors of Open Imagery Network.
-                  All imagery is available to be traced in OpenStreetMap.
+                  , with attribution as contributors of Open Imagery Network, 
+                  unless further specified by a specific license. All imagery 
+                  is available to be traced in OpenStreetMap.
                 </p>
               </div>
 

--- a/src/components/uploader/home.js
+++ b/src/components/uploader/home.js
@@ -29,12 +29,10 @@ function createProgressTracker(progressStats, fileName, component) {
     );
 
     const percentComplete =
-      (progress.sumTotalUploaded / progress.sumFilesize) * 100;
+      progress.sumTotalUploaded / progress.sumFilesize * 100;
     const percentDisplay = Math.round(percentComplete);
     const plural = progressStatsValues.length > 1 ? "s" : "";
-    const uploadStatus = `Uploading ${
-      progressStatsValues.length
-    } image${plural} (${percentDisplay}%).`;
+    const uploadStatus = `Uploading ${progressStatsValues.length} image${plural} (${percentDisplay}%).`;
     component.setState({
       uploadProgress: percentComplete,
       uploadActive: true,
@@ -479,9 +477,9 @@ export default createReactClass({
                   <a href="https://creativecommons.org/licenses/by/4.0/">
                     CC-BY 4.0
                   </a>
-                  , with attribution as contributors of Open Imagery Network, 
-                  unless further specified by a specific license. All imagery 
-                  is available to be traced in OpenStreetMap.
+                  , with attribution as contributors of Open Imagery Network,
+                  unless further specified by a specific license. All imagery is
+                  available to be traced in OpenStreetMap.
                 </p>
               </div>
 

--- a/src/components/uploader/scene.js
+++ b/src/components/uploader/scene.js
@@ -626,6 +626,34 @@ Please check the instructions on how to use files from Google Drive.
                 </a>
               </label>
             </div>
+            <div className="radio">
+              <label>
+                <input
+                  type="radio"
+                  name={this.getRadioName("license")}
+                  onChange={this.onChange}
+                  value="CC BY-NC 4.0"
+                  checked={this.props.data["license"] === "CC BY-NC 4.0"}
+                />
+                <a href="https://creativecommons.org/licenses/by-nc/4.0/">
+                  CC BY-NC 4.0
+                </a>
+              </label>
+            </div>
+            <div className="radio">
+              <label>
+                <input
+                  type="radio"
+                  name={this.getRadioName("license")}
+                  onChange={this.onChange}
+                  value="CC BY-SA 4.0"
+                  checked={this.props.data["license"] === "CC BY-SA 4.0"}
+                />
+                <a href="https://creativecommons.org/licenses/by-sa/4.0/">
+                  CC BY-SA 4.0
+                </a>
+              </label>
+            </div>
           </div>
         </div>
       </fieldset>

--- a/src/components/user_page.js
+++ b/src/components/user_page.js
@@ -109,7 +109,9 @@ export default createReactClass({
                     <li>
                       {this.requestedUser === "current" ? (
                         <span>
-                          <a href={"/#/imagery/" + image._id + "/edit"}>Edit</a>{" "}
+                          <a href={"/#/imagery/" + image._id + "/edit"}>
+                            Edit
+                          </a>{" "}
                           |&nbsp;
                         </span>
                       ) : null}

--- a/src/utils/ds_zoom.js
+++ b/src/utils/ds_zoom.js
@@ -76,7 +76,8 @@ export default L.Control.extend({
     var link = L.DomUtil.create("button", className, container);
     link.innerHTML = html;
 
-    L.DomEvent.on(link, "mousedown dblclick", L.DomEvent.stopPropagation)
+    L.DomEvent
+      .on(link, "mousedown dblclick", L.DomEvent.stopPropagation)
       .on(link, "click", L.DomEvent.stop)
       .on(link, "click", fn, this)
       .on(link, "click", this._refocusOnMap, this);


### PR DESCRIPTION
Adds cc-by-nc and cc-by-sa licenses as options when uploading. 

<img width="662" alt="openaerialmap browser 2018-11-29 19-52-42" src="https://user-images.githubusercontent.com/796838/49248584-fbbeb180-f411-11e8-8f25-8819d02b8081.png">

Lightly tested but needs full deployment to test fully. Right now this places imagery still into the OIN bucket. There are multiple licenses in the OIN bucket but the original goal was to be a single license bucket. Significant impact? 