### PR TITLE
Always call JOSM over http

### DIFF
--- a/src/components/results_item.js
+++ b/src/components/results_item.js
@@ -109,10 +109,7 @@ export default createReactClass({
   onOpenJosm: function(tmsUrl) {
     const data = this.props.data;
     const source = `OpenAerialMap - ${data.provider} - ${data.uuid}`;
-    const urlPrefix =
-      document.location.protocol === "https:"
-        ? "https://127.0.0.1:8112"
-        : "http://127.0.0.1:8111";
+    const urlPrefix = "http://127.0.0.1:8111";
 
     const boundingBox = {
       left: data.bbox[0],


### PR DESCRIPTION
Https in JOSM is unreliable and will be dropped soon. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

w3c/webappsec-mixed-content@349501c
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.