### PR TITLE
Don't apply max value restriction to start date selector

### DIFF
--- a/src/components/uploader/scene.js
+++ b/src/components/uploader/scene.js
@@ -67,7 +67,10 @@ export default class extends React.Component {
     // Try to be helpful by syncing the end date to the start date
     // the first time the start date is changed. Most useful if you
     // go a long way back in time.
-    if (field === "date-start" && this.firstStartDateChange) {
+    if (
+      field === "date-start" &&
+      (this.firstStartDateChange || this.getValueForDate("date-end") < date)
+    ) {
       date.setHours(date.getHours() + 1);
       this.props.onValueChange(
         this.props.index,
@@ -463,7 +466,6 @@ Please check the instructions on how to use files from Google Drive.
           <div className="form-control-set">
             <DateTimePicker
               ref="dateStart"
-              max={this.dateOrUndefined("date-end")}
               finalView="decade"
               timeFormat={"HH:mm"}
               value={this.getValueForDate("date-start")}


### PR DESCRIPTION
Resolves https://github.com/hotosm/oam-uploader/issues/89

- Don't apply max value restriction to the start date selector
- Set the end date with the start date's day, in case the start date is changed to a value after the current end date

## How to test:
I had some trouble to authenticate in my local instance, so I commented the [line 40 of routes.js](https://github.com/hotosm/oam-browser/blob/fix/89-datepicker-behavior/src/routes.js#L40) and accessed http://localhost:3000/#/upload