### PR TITLE
update resolution formatting for user_page

### DIFF
--- a/src/components/user_page.js
+++ b/src/components/user_page.js
@@ -104,7 +104,7 @@ export default createReactClass({
                     <strong>{image.title}</strong>
                     <li>Uploaded: {image.uploaded_at}</li>
                     <li>Sensor: {image.properties.sensor}</li>
-                    <li>Resolution: {image.gsd}m</li>
+                    <li>Resolution: {utils.gsdToUnit(image.gsd)}</li>
                     <li>File size: {image.file_size / 1000}k</li>
                     <li>
                       {this.requestedUser === "current" ? (


### PR DESCRIPTION
the user page currently shows the resolution as an extremely long decimal
<img width="749" alt="Screen Shot 2021-07-08 at 12 23 02 PM" src="https://user-images.githubusercontent.com/4806884/124957628-4865c280-dfe7-11eb-9fe0-f2f07379459e.png">

i think this PR should implement for the user page the same formatting as implemented on the [results_list_card.js#L54](https://github.com/hotosm/oam-browser/blob/develop/src/components/results_list_card.js#L54) when browsing
<img width="234" alt="Screen Shot 2021-07-08 at 12 25 40 PM" src="https://user-images.githubusercontent.com/4806884/124957963-a2ff1e80-dfe7-11eb-9a7c-628697e1513d.png"> 
