### PR TITLE
Adding source=OpenAerialMap Automatically when Opening in OpenstreetMap.org

### DIFF
--- a/src/components/results_item.js
+++ b/src/components/results_item.js
@@ -218,6 +218,7 @@ export default createReactClass({
       "http://www.openstreetmap.org/edit?editor=id" +
       "#map=" +
       [zoom, center[1], center[0]].join("/") +
+      "&source=OpenAerialMap" +
       "&" +
       qs.stringify({
         background: "custom:" + this.props.data.properties.tms


### PR DESCRIPTION
when opening image in openstreetmap.org it will automatically have the source OpenAerialMap

<img width="402" height="305" alt="Screenshot 2025-07-19 at 11 52 45" src="https://github.com/user-attachments/assets/7a188fa3-c676-454b-bfdd-b7bab5db73ab" />

It will make it easier for other people to find back the source image, and it helps promote OAM
