### PR TITLE
Add item id to metadata list in results pane

### DIFF
--- a/src/components/results_item.js
+++ b/src/components/results_item.js
@@ -491,6 +491,10 @@ export default createReactClass({
                   {d.properties.license}
                 </a>
               </dd>
+              <dt>
+                <span>ID</span>
+              </dt>
+              <dd>{d._id}</dd>
             </dl>
 
             {d.custom_tms ? (


### PR DESCRIPTION
Having the item ID as plain text in the metadata sidebar (results-pane) would enable a user to copy the ID easily to use it somewhere else (E.g. in the next version of the [SketchMapTool](https://sketch-map-tool.heigit.org/) to use the OpenAerialMap Image as base map on Sketch Maps).

Unfortunately, I had CORS issues during development so that I could not test this change.
I would very much appreciate it if somebody could check this is working as expected before merging. Thanks!